### PR TITLE
Remove traceback error for uniformly deep footing.py

### DIFF
--- a/Critical perimeter.py
+++ b/Critical perimeter.py
@@ -1,5 +1,5 @@
-
 from dxfwrite import DXFEngine as dxf
+from dxfwrite.const import CENTER
 import csv
 import math
 import pdb

--- a/Shear.py
+++ b/Shear.py
@@ -1,4 +1,5 @@
 from dxfwrite import DXFEngine as dxf
+from dxfwrite.const import CENTER
 
 import csv
 

--- a/Sloped footing(b).py
+++ b/Sloped footing(b).py
@@ -1,4 +1,5 @@
 from dxfwrite import DXFEngine as dxf
+from dxfwrite.const import CENTER
 
 import csv
 

--- a/Sloped footing(c).py
+++ b/Sloped footing(c).py
@@ -1,4 +1,5 @@
 from dxfwrite import DXFEngine as dxf
+from dxfwrite.const import CENTER
 
 import csv
 

--- a/Stepped footing.py
+++ b/Stepped footing.py
@@ -1,4 +1,5 @@
 from dxfwrite import DXFEngine as dxf
+from dxfwrite.const import CENTER
 
 import csv
 

--- a/Uniformly deep footing.py
+++ b/Uniformly deep footing.py
@@ -1,4 +1,5 @@
 from dxfwrite import DXFEngine as dxf
+from dxfwrite.const import CENTER
 import csv
 import math
 
@@ -55,7 +56,6 @@ final_arrow_points = zip(list_bottom_points,list_arrow_points)
 for i in xrange(len(final_arrow_points)):
     arrow(final_arrow_points[i][0], final_arrow_points[i][1])
 
-print "'" + drawing_name + ".dxf'", "file generated in the same directory"
 
 #text
 
@@ -111,6 +111,7 @@ drawing.add(dxf.line((50, 45), (52, 47)))
 
 drawing.save()
 
+print "'" + drawing_name + ".dxf'", "file generated in the same directory"
 
 
 


### PR DESCRIPTION
It had an error and the dxf file wasn't generated.
Help taken from here: https://pythonhosted.org/dxfwrite/entities/text.html
